### PR TITLE
Forces node v16 and legacy openssl provider

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,9 @@
 {
   "name": "star-chart",
   "version": "0.1.0",
+  "engines": {
+    "node": ">=16.0.0 <17.0.0"
+  },
   "private": true,
   "proxy": "http://localhost:3001",
   "dependencies": {
@@ -22,8 +25,8 @@
     "jwt-decode": "^2.2.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts start --openssl-legacy-provider start",
+    "build": "react-scripts build --openssl-legacy-provider build",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
Hi Jenny,

My apologies.  Finally got a minute to look at this.

First, you have to make sure you're using Node v16.x  I was using 18 and had to downgrade.  Not a hard thing at all with nvm.  Just did `nvm install v16.14.0` and `nvm use v16.14.0`.

Second, I updated the start scripts for create react app to insure it was using legacy openssl provider.  

Once you merge this, make sure your on the compatible version of node and run `npm i` from the root.  Then `npm run develop`

Let me know if this helps!  Keep me posted.

--Mark